### PR TITLE
Improve SEO on the receipt splitter tool

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://samnesler.com/sitemap-index.xml

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,0 +1,52 @@
+---
+interface Props {
+  metadata?: {
+    title?: string;
+    description?: string;
+    image?: string;
+    imageAlt?: string;
+    url?: string;
+    type?: string;
+    jsonLd?: Record<string, unknown> | Record<string, unknown>[];
+  };
+}
+
+const { metadata = {} } = Astro.props;
+
+const title = metadata.title || 'Sam Nesler';
+const description = metadata.description || "Sam's lovely site";
+const image = metadata.image || 'https://tsuni.dev/images/port_website.png';
+const imageAlt = metadata.imageAlt || title;
+const type = metadata.type || 'website';
+
+// Canonical / og:url always point at the production site, regardless of the
+// host the page is served from.
+const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+---
+
+<link rel="sitemap" href="/sitemap-index.xml" />
+<link rel="canonical" href={canonical} />
+
+<title>{title}</title>
+<meta name="description" content={description} />
+<meta name="image" content={image} />
+<meta name="url" content={canonical} />
+<meta name="theme-color" content="#fbcfe8" />
+
+<meta property="og:type" content={type} />
+<meta property="og:site_name" content="Sam Nesler" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:url" content={canonical} />
+<meta property="og:image" content={image} />
+<meta property="og:image:alt" content={imageAlt} />
+
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={image} />
+
+<link rel="alternate" type="application/rss+xml" title="Sam Nesler RSS Feed" href={new URL('rss.xml', Astro.site)} />
+
+{metadata.jsonLd && <script type="application/ld+json" set:html={JSON.stringify(metadata.jsonLd)} is:inline />}

--- a/src/components/tools/BillSplitter/BillSplitter.tsx
+++ b/src/components/tools/BillSplitter/BillSplitter.tsx
@@ -90,7 +90,7 @@ export default function BillSplitter() {
     <>
       <link href={FONT_LINK} rel="stylesheet" />
       <div
-        className="relative mx-auto min-h-screen max-w-[480px]"
+        className="relative mx-auto max-w-[480px]"
         style={{
           fontFamily: "'DM Sans', sans-serif",
           background: palette.bg,

--- a/src/components/tools/BillSplitter/UploadScreen.tsx
+++ b/src/components/tools/BillSplitter/UploadScreen.tsx
@@ -13,22 +13,7 @@ export default function UploadScreen({ onImage, parsing, error }: UploadScreenPr
   const [dragOver, setDragOver] = useState(false);
 
   return (
-    <div className="flex min-h-screen flex-col px-5 pt-6 pb-6">
-      <div className="mb-8 pt-5 text-center">
-        <div className="mb-2 text-[40px]">🍜</div>
-        <h1
-          className="mb-1 text-[30px] font-bold tracking-[-0.02em]"
-          style={{
-            fontFamily: "'Fraunces', serif"
-          }}
-        >
-          Split the Bill
-        </h1>
-        <p className="m-0 text-[15px] leading-normal" style={{ color: palette.textSoft }}>
-          Scan a receipt. Assign items. Done.
-        </p>
-      </div>
-
+    <div className="flex flex-col px-5 pt-6 pb-6">
       <div
         onDragOver={event => {
           event.preventDefault();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import '@/styles/global.css';
 
 import Font from 'astro/components/Font.astro';
 
+import BaseHead from '@/components/BaseHead.astro';
 import Background from '@/components/Background.astro';
 import Header from '@/components/header/Header.astro';
 
@@ -11,7 +12,10 @@ interface Props {
     title?: string;
     description?: string;
     image?: string;
+    imageAlt?: string;
     url?: string;
+    type?: string;
+    jsonLd?: Record<string, unknown> | Record<string, unknown>[];
   };
   fancyBackground?: boolean;
 }
@@ -26,24 +30,13 @@ const { metadata = {}, fancyBackground = false } = Astro.props;
     <Font cssVariable="--font-rubik" />
     <Font cssVariable="--font-neon" />
     <link rel="preconnect" href="https://net.tsuni.dev" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
     <script is:inline defer data-domain="tsuni.dev" src="https://net.tsuni.dev/js/script.js"></script>
     <script>
       addEventListener('load', () => {
         document.documentElement.classList.remove('noAnimate');
       });
     </script>
-    <title>{metadata?.title || 'Sam Nesler'}</title>
-    <meta name="description" content={metadata?.description || "Sam's lovely site"} />
-    <meta name="image" content={metadata?.image || 'https://tsuni.dev/images/port_website.png'} />
-    <meta name="url" content={metadata?.url || 'https://tsuni.dev'} />
-    <meta name="theme-color" content="#fbcfe8" />
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      title="Sam Nesler RSS Feed"
-      href={new URL("rss.xml", Astro.site)}
-    />
+    <BaseHead {metadata} />
   </head>
   <body>
     <Header />

--- a/src/layouts/ThinLayout.astro
+++ b/src/layouts/ThinLayout.astro
@@ -3,12 +3,17 @@ import '@/styles/global.css';
 
 import Font from 'astro/components/Font.astro';
 
+import BaseHead from '@/components/BaseHead.astro';
+
 interface Props {
   metadata?: {
     title?: string;
     description?: string;
     image?: string;
+    imageAlt?: string;
     url?: string;
+    type?: string;
+    jsonLd?: Record<string, unknown> | Record<string, unknown>[];
   };
   fancyBackground?: boolean;
 }
@@ -23,24 +28,13 @@ const { metadata = {} } = Astro.props;
     <Font cssVariable="--font-rubik" />
     <Font cssVariable="--font-neon" />
     <link rel="preconnect" href="https://net.tsuni.dev" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
     <script is:inline defer data-domain="tsuni.dev" src="https://net.tsuni.dev/js/script.js"></script>
     <script>
       addEventListener('load', () => {
         document.documentElement.classList.remove('noAnimate');
       });
     </script>
-    <title>{metadata?.title || 'Sam Nesler'}</title>
-    <meta name="description" content={metadata?.description || "Sam's lovely site"} />
-    <meta name="image" content={metadata?.image || 'https://tsuni.dev/images/port_website.png'} />
-    <meta name="url" content={metadata?.url || 'https://tsuni.dev'} />
-    <meta name="theme-color" content="#fbcfe8" />
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      title="Sam Nesler RSS Feed"
-      href={new URL("rss.xml", Astro.site)}
-    />
+    <BaseHead {metadata} />
   </head>
   <body>
     <slot />

--- a/src/pages/tools/bill-splitter.astro
+++ b/src/pages/tools/bill-splitter.astro
@@ -1,15 +1,197 @@
 ---
 import BillSplitterTool from '@/components/tools/BillSplitter/BillSplitter';
+import { FONT_LINK, palette } from '@/components/tools/BillSplitter/styles';
 import ThinLayout from '@/layouts/ThinLayout.astro';
+
+const title = 'Receipt Splitter — Scan a Receipt & Split the Bill Free';
+const description =
+  'Free online receipt splitter. Snap a photo of your receipt, assign items to each person, and split the total with tax and tip — no signup, works on any phone.';
+
+const canonical = new URL('/tools/bill-splitter', Astro.site).toString();
+
+const steps = [
+  {
+    name: 'Upload a receipt photo',
+    text: 'Take a photo of your receipt or drag in an image. The receipt is scanned automatically and every line item is read for you.'
+  },
+  {
+    name: 'Assign items to people',
+    text: 'Add the people sharing the bill and tap to assign each item. Shared items are split evenly between everyone on them.'
+  },
+  {
+    name: 'Split the total with tax and tip',
+    text: "Set tax and tip as a percentage or a flat amount. You'll get a clear per-person total that adds up to the receipt."
+  }
+];
+
+const features = [
+  'Scans receipts automatically — no manual typing of every line item.',
+  'Split items between any number of people, including shared dishes.',
+  'Add tax and tip as a percentage or a flat amount.',
+  'Works in the browser on any phone or laptop — nothing to install.',
+  'Completely free with no account or signup required.'
+];
+
+const faqs = [
+  {
+    q: 'How do you split a restaurant bill by item?',
+    a: 'Upload a photo of the receipt, add everyone sharing the bill, then assign each line item to the person who ordered it. Items shared by several people are divided evenly between them, and tax and tip are split in proportion to each person’s subtotal.'
+  },
+  {
+    q: 'Is the receipt splitter free?',
+    a: 'Yes. The receipt splitter is completely free to use, with no account, signup, or app download required.'
+  },
+  {
+    q: 'How is tax and tip divided between people?',
+    a: 'Tax and tip are shared proportionally to what each person ordered, so someone who spent more covers a larger share. You can enter tax and tip as a percentage or as a flat dollar amount.'
+  },
+  {
+    q: 'Do you store my receipt photos?',
+    a: 'Your receipt photo is sent to the server only to read the items on it, and the split itself is calculated in your browser. Photos are not saved to your account because there is no account.'
+  },
+  {
+    q: 'Can I split a bill between more than two people?',
+    a: 'Yes. You can add as many people as you like and assign any item to one person or share it across the whole group.'
+  }
+];
+
+const jsonLd = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Receipt Splitter',
+    url: canonical,
+    applicationCategory: 'FinanceApplication',
+    operatingSystem: 'Web',
+    description,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD'
+    },
+    creator: {
+      '@type': 'Person',
+      name: 'Sam Nesler',
+      url: 'https://samnesler.com'
+    }
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: 'How to split a receipt between people',
+    description: 'Split a restaurant or grocery receipt by item and share tax and tip fairly.',
+    step: steps.map((step, index) => ({
+      '@type': 'HowToStep',
+      position: index + 1,
+      name: step.name,
+      text: step.text
+    }))
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map(faq => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.a
+      }
+    }))
+  }
+];
 ---
 
 <ThinLayout
   metadata={{
-    title: 'Bill Splitter',
-    description: 'Scan a receipt, assign items to people, and split the total with tax and tip.'
+    title,
+    description,
+    type: 'website',
+    jsonLd
   }}
 >
-  <BillSplitterTool client:load />
+  <link href={FONT_LINK} rel="stylesheet" />
+
+  <main class="mx-auto w-full max-w-[480px] px-5" style={{ fontFamily: "'DM Sans', sans-serif", color: palette.text }}>
+    <header class="pt-12 pb-2 text-center">
+      <div class="mb-2 text-[40px]">🍜</div>
+      <h1 class="mb-2 text-[34px] leading-tight font-bold tracking-[-0.02em]" style={{ fontFamily: "'Fraunces', serif" }}>Receipt Splitter</h1>
+      <p class="mx-auto mb-5 max-w-[36ch] text-[16px] leading-relaxed" style={{ color: palette.textSoft }}>
+        Snap a photo of your receipt, assign items to each person, and split the total with tax and tip — instantly. Free, no signup.
+      </p>
+      <ul class="mx-auto flex max-w-[28ch] flex-col gap-1.5 text-left text-[14px]" style={{ color: palette.textSoft }}>
+        <li>📷 Scans your receipt automatically</li>
+        <li>👥 Splits items across any number of people</li>
+        <li>🧮 Shares tax &amp; tip fairly</li>
+      </ul>
+    </header>
+
+    <BillSplitterTool client:load />
+
+    <section class="border-t pt-10 pb-2" style={{ borderColor: palette.border }}>
+      <h2 class="mb-5 text-[24px] font-bold tracking-[-0.01em]" style={{ fontFamily: "'Fraunces', serif" }}>How it works</h2>
+      <ol class="flex flex-col gap-5">
+        {
+          steps.map((step, index) => (
+            <li class="flex gap-3.5">
+              <span
+                class="flex h-8 w-8 flex-none items-center justify-center rounded-full text-[15px] font-semibold"
+                style={{ background: palette.accentSoft, color: palette.accent }}
+              >
+                {index + 1}
+              </span>
+              <div>
+                <h3 class="mb-1 text-[16px] font-semibold">{step.name}</h3>
+                <p class="m-0 text-[14px] leading-relaxed" style={{ color: palette.textSoft }}>
+                  {step.text}
+                </p>
+              </div>
+            </li>
+          ))
+        }
+      </ol>
+    </section>
+
+    <section class="mt-10 border-t pt-10" style={{ borderColor: palette.border }}>
+      <h2 class="mb-5 text-[24px] font-bold tracking-[-0.01em]" style={{ fontFamily: "'Fraunces', serif" }}>Why use it</h2>
+      <ul class="flex flex-col gap-3">
+        {
+          features.map(feature => (
+            <li class="flex gap-2.5 text-[15px] leading-relaxed">
+              <span aria-hidden="true" style={{ color: palette.green }}>
+                ✓
+              </span>
+              <span>{feature}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section class="mt-10 border-t pt-10" style={{ borderColor: palette.border }}>
+      <h2 class="mb-5 text-[24px] font-bold tracking-[-0.01em]" style={{ fontFamily: "'Fraunces', serif" }}>Frequently asked questions</h2>
+      <div class="flex flex-col gap-6">
+        {
+          faqs.map(faq => (
+            <div>
+              <h3 class="mb-1.5 text-[16px] font-semibold">{faq.q}</h3>
+              <p class="m-0 text-[14px] leading-relaxed" style={{ color: palette.textSoft }}>
+                {faq.a}
+              </p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <footer class="mt-10 border-t py-10 text-center text-[13px]" style={{ borderColor: palette.border, color: palette.textSoft }}>
+      <p class="m-0">
+        Your receipt photo is only used to read the items on it. Built by{' '}
+        <a href="https://samnesler.com" style={{ color: palette.accent }}> Sam Nesler </a>
+        .
+      </p>
+    </footer>
+  </main>
 </ThinLayout>
 
 <style is:global>


### PR DESCRIPTION
## Why

The receipt splitter at `/tools/bill-splitter` was rendered **entirely client-side** (`<BillSplitterTool client:load />`), so crawlers, social-card scrapers, and LLMs fetching the URL saw an essentially empty shell — no `<h1>`, no copy, no description of what the tool does. The shared layouts also emitted only a bare `<title>` + `description` with no OpenGraph, Twitter cards, canonical URLs, or structured data anywhere on the site.

## What changed

**Static, indexable landing page** (`src/pages/tools/bill-splitter.astro`)
- Server-rendered hero (single `<h1>`), how-it-works steps, features, FAQ, and privacy footer — all real HTML, targeting the **"receipt splitter"** keyword.
- The interactive tool remains a `client:load` island in the page flow.

**Site-wide meta** (new `src/components/BaseHead.astro`, used by `Layout` + `ThinLayout`)
- Adds OpenGraph, Twitter `summary_large_image` cards, `<link rel="canonical">` (always `samnesler.com`), and optional JSON-LD.
- De-duplicates the previously identical `<head>` blocks in the two layouts.

**Structured data** on the tool page: `WebApplication` (free `Offer`), `HowTo`, and `FAQPage`.

**Tool tweaks**: removed the now-duplicate in-tool hero from `UploadScreen`, relaxed forced `min-h-screen` so the landing sections flow below the tool.

**`public/robots.txt`**: allow-all + sitemap reference.

## Verification

- `pnpm build` succeeds; server HTML for the page contains the H1, FAQ copy, and a JSON-LD block parsing to `WebApplication` + `HowTo` + `FAQPage`.
- `og:*` / `twitter:*` / canonical confirmed both on the tool page and a regular page (home) since the change is site-wide.
- `robots.txt` and the sitemap entry for the tool are present in `dist`.
- `pnpm lint` clean (only pre-existing warnings in a generated file). No test files exist in the repo.

### Notes / follow-ups
- A dedicated 1200×630 OG image for the tool would further improve social cards; it currently falls back to the site default.
- Pre-existing `tsuni.dev` vs `samnesler.com` mismatch in the default share image is left as-is; canonical/og:url correctly use `samnesler.com`.

https://claude.ai/code/session_01EeoLUywv7Wz9z7iWTx3PZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeoLUywv7Wz9z7iWTx3PZX)_